### PR TITLE
Find :default key in lookup path to use as default

### DIFF
--- a/app/helpers/title/title_helper.rb
+++ b/app/helpers/title/title_helper.rb
@@ -14,7 +14,7 @@ module Title
       def to_s
         I18n.t(
           [:titles, controller_name, action_name].join('.'),
-          context.merge(default: [application_title, guess_title])
+          context.merge(default: defaults)
         )
       end
 
@@ -30,8 +30,22 @@ module Title
         Rails.application.class.to_s.split('::').first
       end
 
+      def defaults
+        default_keys_in_lookup_path + [application_title, guess_title]
+      end
+
       def controller_name
         controller_path.gsub('/', '.')
+      end
+
+      def default_keys_in_lookup_path
+        defaults = []
+        lookup_path = controller_name.split('.')
+        while lookup_path.length > 0
+          defaults << ['titles', *lookup_path, 'default'].join('.').to_sym
+          lookup_path.pop
+        end
+        defaults.reverse
       end
     end
   end

--- a/spec/helpers/title_helper_spec.rb
+++ b/spec/helpers/title_helper_spec.rb
@@ -17,6 +17,14 @@ describe Title::TitleHelper do
     expect(helper.title).to eq('Not Dummy')
   end
 
+  it 'uses a :default key at an arbitrary point in the lookup path' do
+    stub_rails
+    stub_controller_and_action('engine/users', :show)
+    load_translations(engine: { default: 'Engine name' })
+
+    expect(helper.title).to eq 'Engine name'
+  end
+
   it 'matches controller/action to translation and uses that title' do
     stub_rails
     stub_controller_and_action(:dashboards, :show)

--- a/title.gemspec
+++ b/title.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'pry'
 
   spec.add_dependency 'rails', '>= 3.1'
   spec.add_dependency 'i18n'


### PR DESCRIPTION
If a key isn't found, before using application title or guessing the title,
look for `:default` in the lookup path.

For example, in `users#show`, `titles.users.default` would be used if
`titles.users.show` were not present.
