### PR TITLE
Make context safe for interpolation

### DIFF
--- a/app/helpers/title/title_helper.rb
+++ b/app/helpers/title/title_helper.rb
@@ -15,7 +15,7 @@ module Title
       def to_s
         I18n.t(
           [:titles, controller_name, action_name].join('.'),
-          context.merge(default: defaults)
+          safe_context.merge(default: defaults)
         )
       end
 
@@ -58,6 +58,10 @@ module Title
         else
           action_name
         end
+      end
+
+      def safe_context
+        context.except(*I18n::RESERVED_KEYS)
       end
     end
   end

--- a/spec/helpers/title_helper_spec.rb
+++ b/spec/helpers/title_helper_spec.rb
@@ -51,6 +51,15 @@ describe Title::TitleHelper do
     expect(helper.title(greeting: 'Hello')).to eq('Hello Caleb')
   end
 
+  it 'makes context safe to be passed as interpolation options' do
+    stub_rails
+    stub_controller_and_action(:users, :show)
+    load_translations(users: { show: 'User' })
+    allow(helper).to receive_message_chain(:controller, :view_assigns).and_return('scope' => 'Foo')
+
+    expect(helper.title).to eq('User')
+  end
+
   def stub_rails
     allow(helper).to receive(:controller_path).and_return('dashboards')
     allow(helper).to receive(:action_name)


### PR DESCRIPTION
Fixes an issue related to colliding context and i18n reserved keys, which results in application name being rendered on translation lookup failure. The chance of encountering this problem is real as some of these names are relatively common terms.

- `cascade`
- `deep_interpolation`
- `fallback`
- `fallback_in_progress`
- `format`
- `object`
- `raise`
- `resolve`
- `scope`
- `separator`
- `throw`

Please see: https://github.com/svenfuchs/i18n/blob/405b672ed121d48d2e41140da29f63b350b9899e/lib/i18n.rb#L15.

This change filters out reserved keys from context before translation.