### PR TITLE
Use RSpec without monkey-patching mode

### DIFF
--- a/spec/helpers/title_helper_spec.rb
+++ b/spec/helpers/title_helper_spec.rb
@@ -3,7 +3,7 @@ Coveralls.wear!
 
 require 'title'
 
-describe Title::TitleHelper do
+RSpec.describe Title::TitleHelper do
   it 'is the app name when no translation is present' do
     stub_rails
 


### PR DESCRIPTION
This PR stops using the "globally accessible parts of RSpec", described here: https://relishapp.com/rspec/rspec-core/v/3-9/docs/configuration/zero-monkey-patching-mode