### PR TITLE
Allow using Bundler 2 in development

### DIFF
--- a/title.gemspec
+++ b/title.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ['lib', 'app']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
This PR changes the version description on Bundler in development mode to include also Bundler 2.x.