### PR TITLE
Fix warning for Ruby 2.7

### DIFF
--- a/app/helpers/title/title_helper.rb
+++ b/app/helpers/title/title_helper.rb
@@ -15,7 +15,7 @@ module Title
       def to_s
         I18n.t(
           [:titles, controller_name, action_name].join('.'),
-          safe_context.merge(default: defaults)
+          **safe_context.merge(default: defaults)
         )
       end
 


### PR DESCRIPTION
This Pull Request fixes the warning with Ruby 2.7 (similar to https://github.com/ruby-i18n/i18n/pull/486).

[`I18n.t`](https://github.com/ruby-i18n/i18n/blob/06aa9ac0685aa74eca8cdb4cd7eb10c75969eb6d/lib/i18n.rb#L179) defined as follows:

```ruby
def translate(key = nil, *, throw: false, raise: false, locale: nil, **options)
```

With Ruby 2.7, we need to be explicit to pass in double splat options. Otherwise warning will be thorwn:

```
/Users/fengdi/.gem/ruby/2.7.0/gems/title-0.0.7/app/helpers/title/title_helper.rb:16: warning: Using the last argument as keyword parameters is deprecated
```

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0

Tested on my rails app that this PR removed the warning.